### PR TITLE
Add support for activeBackgroundColor for focused tab on Android

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -405,6 +405,8 @@ export default class TabBar extends PureComponent<DefaultProps, Props, State> {
               const tabStyle = {};
 
               tabStyle.opacity = opacity;
+              const { activeBackgroundColor } = this.props;
+              if( focused && activeBackgroundColor ) tabStyle.backgroundColor = activeBackgroundColor;
 
               if (icon) {
                 if (label) {


### PR DESCRIPTION
See it in action [here](https://www.dropbox.com/s/1n06oqpz985xhky/a3.mov?dl=0), focused tab is marked in red.

Main use case is when putting the tabBar atop on iOS and, I need it to scroll horizontally and also have focused tab highlighted (with `activeBackgroundColor` style), hence the PR.